### PR TITLE
Upgrade runtime from gnome 42 to 43

### DIFF
--- a/com.leinardi.gwe.json
+++ b/com.leinardi.gwe.json
@@ -2,7 +2,7 @@
   "app-id": "com.leinardi.gwe",
   "command": "gwe",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "42",
+  "runtime-version": "43",
   "sdk": "org.gnome.Sdk",
   "finish-args": [
     "--share=ipc",


### PR DESCRIPTION
org.gnome.Platform 42 is end-of -life since March 21, 2023. Upgrading to 43.